### PR TITLE
Escape the injected linkdashConfig script code

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Check out the [examples folder](https://github.com/igimanaloto/linkdash/blob/mas
 
 ## Under the hood
 
-Linkdash simply swaps the contents of a prebuilt html file with your config. Check out the [package.json ](https://github.com/igimanaloto/linkdash/blob/master/package.json) to see the three depedencies it installs!
+Linkdash simply swaps the contents of a prebuilt html file with your config. Check out the [package.json ](https://github.com/igimanaloto/linkdash/blob/master/package.json) to see the four depedencies it installs!
 
 ## Happy customers
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "command-line-args": "^5.1.1",
     "command-line-usage": "^6.1.0",
+    "jsesc": "^3.0.1",
     "open": "^7.0.3"
   },
   "devDependencies": {
@@ -50,6 +51,7 @@
     "@types/command-line-args": "^5.0.0",
     "@types/command-line-usage": "^5.0.1",
     "@types/jest": "^25.2.1",
+    "@types/jsesc": "^2.5.0",
     "@types/match-sorter": "^4.0.0",
     "@types/querystringify": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "^2.27.0",

--- a/site/demo/conf.yaml
+++ b/site/demo/conf.yaml
@@ -188,3 +188,6 @@ urls:
   - title: Something long that should break the flow so we can test this thing and see how it renders on smaller screens
     href: https://www.producthunt.com/
     group: Veryveryverylong type
+  - title: "It should escape \n naughty strings like </span> <script></html><//><b>What."
+    href: "<jsx>!->>/**8*//* */</html><//><b>What."
+    group: "Naughty entry"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,6 @@ const App = function () {
         if (!confie.urls) throw Error(words.errorLoading);
 
         confie.urls = confie.urls.map((x) => {
-          console.log([x.group, x.title].join("_"));
           return {
             id:
               x.id ||

--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,7 @@
     <script>
       //_linkdashConfig
       <% if (htmlWebpackPlugin.options.linkdashConfig){ %>
-        window.linkdashConfig = JSON.parse(`<%= JSON.stringify(htmlWebpackPlugin.options.linkdashConfig) %>`);
+        window.linkdashConfig = <%= htmlWebpackPlugin.options.linkdashConfig %>;
       <% } %>
     </script>
     <%= htmlWebpackPlugin.options.htmlHead %>

--- a/src_lib/index.test.ts
+++ b/src_lib/index.test.ts
@@ -1,4 +1,5 @@
 import * as _fs from "fs";
+import jsesc from "jsesc";
 import { mocked } from "ts-jest/utils";
 import { buildTemplate, loadConfig, loadConfigSync } from "./index";
 import _loadFile from "./loadFile";
@@ -96,7 +97,13 @@ describe("buildTemplate", () => {
     };
     const { htmlHead, ...injectable } = opts;
     const result = buildTemplate(opts);
-    expect(result).toContain(JSON.stringify(injectable));
+    const escaped = jsesc(injectable as any, {
+      isScriptContext: true,
+      json: true,
+      // For testing - turn the escaped object into a string
+      wrap: true,
+    });
+    expect(result).toContain(escaped);
     expect(result).toContain(htmlHead);
   });
 });

--- a/src_lib/index.ts
+++ b/src_lib/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import fs from "fs";
+import jsesc from "jsesc";
 import path from "path";
 import loadFile from "./loadFile";
 import { IBuildTemplateOptions } from "./types";
@@ -14,10 +15,11 @@ export const buildTemplate = (options: IBuildTemplateOptions) => {
   validateConfig(options);
   let template = fs.readFileSync(TEMPLATE_BASE).toString();
   const { htmlHead, ...filteredOptions } = options;
-  template = template.replace(
-    "//_linkdashConfig",
-    `window.linkdashConfig = JSON.parse(\`${JSON.stringify(filteredOptions)}\`)`
-  );
+  const escapedConfig = jsesc(filteredOptions as any, {
+    isScriptContext: true,
+    json: true,
+  });
+  template = template.replace("//_linkdashConfig", `window.linkdashConfig = ${escapedConfig};`);
 
   template = template.replace('<meta name="linkdashHead" content=""/>', htmlHead || "");
 

--- a/src_lib/validateConfig.ts
+++ b/src_lib/validateConfig.ts
@@ -1,7 +1,9 @@
+import { ILinkdashFileConfig } from "./types";
+
 /**
  * Validates the minimum config required for a template to be built.
  */
-const validateConfig = (fileOptions: any) => {
+const validateConfig = (fileOptions: ILinkdashFileConfig) => {
   if (typeof fileOptions !== "object" || !fileOptions || (!fileOptions.urls && !fileOptions.host)) {
     throw Error("Invalid config supplied");
   }

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -1,6 +1,7 @@
 const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
+const jsesc = require("jsesc");
 
 const CWD = process.cwd();
 const DIR_DEST = path.join(CWD, "build");
@@ -12,9 +13,14 @@ const loadConfig = () => {
     "../site/demo/demo.config.js"
   ))();
 
+  const escaped = jsesc(linkdashConfig, {
+    isScriptContext: true,
+    json: true,
+  });
+
   return {
     htmlHead,
-    linkdashConfig,
+    linkdashConfig: escaped,
   };
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1257,6 +1257,11 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
+"@types/jsesc@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@types/jsesc/-/jsesc-2.5.0.tgz#40e2de0f4f0e292f172589e75cfb17b6a6db09c4"
+  integrity sha512-rhKX1CpHA4NH3H/tXpuHAOLCIrJOV6Dm2rtv5J4jQt9tJ801+IIz9yhj2lHl/m5l7NCS94pODN7kLeAcqEaq/g==
+
 "@types/json-schema@^7.0.3":
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
@@ -5713,6 +5718,11 @@ jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
+
+jsesc@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.0.1.tgz#0e10205322721c22716cd5bbdbf80e71fb9c8344"
+  integrity sha512-w+MMxnByppM4jwskitZotEtvtO3a2C7WOz31NxJToGisHuysCAQQU7umb/pA/6soPFe8LGjXFEFbuPuLEPm7Ag==
 
 jsesc@~0.5.0:
   version "0.5.0"


### PR DESCRIPTION
replace json.stringify/parse with jssec to escape linkdashConfig header script injection.

The previous implementation was using a simple json.stringify / json.parse approach which breaks with
escaped characters such as the newline (\n) and dom e.g. </script> tags.

